### PR TITLE
Renamed variable `des_ip` to `dst_ip` for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Change field name `duration` to `last_time`.
+- Renamed variable `des_ip` to `dst_ip` for consistency with the naming
+  convention of `src_ip`.
 
 ## [0.1.0] - 2023-03-27
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -492,7 +492,7 @@ mod tests {
             start: 0,
             id: "1".to_string(),
             src_ip: Some("192.168.4.76".parse::<IpAddr>().unwrap()),
-            des_ip: Some("31.3.245.133".parse::<IpAddr>().unwrap()),
+            dst_ip: Some("31.3.245.133".parse::<IpAddr>().unwrap()),
             source: Some("world".to_string()),
         };
         super::send_stream_request(

--- a/src/publish/stream.rs
+++ b/src/publish/stream.rs
@@ -94,6 +94,6 @@ pub struct RequestCrusherStream {
     pub start: i64,
     pub id: String,
     pub src_ip: Option<IpAddr>,
-    pub des_ip: Option<IpAddr>,
+    pub dst_ip: Option<IpAddr>,
     pub source: Option<String>,
 }


### PR DESCRIPTION
This change improves readability and maintainability of the code by using consistent abbreviations for "source" and "destination."