### PR TITLE
Make `RecordType` `#[non_exhaustive]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Add `source` to ftp's csv field.
+- Added the source field to the CSV record of an FTP connection. This
+  additional field makes the FTP record compatible with other CSV records.
+- `RecordType` became `#[non_exhaustive]`. This change ensures that adding new
+  record types in the future will not result in breaking changes for downstream
+  users who have exhaustively matched on the `RecordType` variants. This makes
+  it easier for both the library maintainers and users to evolve the codebase
+  and adapt to new requirements without introducing breaking changes.
 
 ## [0.4.0] - 2023-04-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     Clone, Copy, Debug, Hash, Deserialize, Eq, IntoPrimitive, PartialEq, Serialize, TryFromPrimitive,
 )]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum RecordType {
     Conn = 0,
     Dns = 1,


### PR DESCRIPTION
This change ensures that adding new record types in the future will not result in breaking changes for downstream users who have exhaustively matched on the `RecordType` variants. This makes it easier for both the library maintainers and users to evolve the codebase and adapt to new requirements without introducing breaking changes.