### PR TITLE
Make convert_time_format a private function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- `convert_time_format` function is no longer available as a public function in
+  the API. It has been made private to avoid exposing the internal protocol
+  format used for network transmission.
+
 ## [0.5.0] - 2023-04-26
 
 ### Changed
@@ -56,6 +64,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[Unreleased]: https://github.com/aicers/giganto-client/compare/0.5.0...main
 [0.5.0]: https://github.com/aicers/giganto-client/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/aicers/giganto-client/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/aicers/giganto-client/compare/0.3.0...0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.5.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ingest/network.rs
+++ b/src/ingest/network.rs
@@ -1,5 +1,6 @@
-use crate::{convert_time_format, publish::range::ResponseRangeData};
+use crate::publish::range::ResponseRangeData;
 use anyhow::Result;
+use chrono::NaiveDateTime;
 use num_enum::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -639,4 +640,13 @@ fn as_str_or_default(s: &str) -> &str {
     } else {
         s
     }
+}
+
+/// Converts a timestamp to a string in the format of "%s%.9f", which is the format used by Zeek.
+#[must_use]
+fn convert_time_format(timestamp: i64) -> String {
+    const A_BILLION: i64 = 1_000_000_000;
+    let nsecs = u32::try_from(timestamp % A_BILLION).unwrap_or_default();
+    NaiveDateTime::from_timestamp_opt(timestamp / A_BILLION, nsecs)
+        .map_or("-".to_string(), |s| s.format("%s%.9f").to_string())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,22 +6,12 @@ pub mod publish;
 mod test;
 
 use anyhow::{bail, Result};
-use chrono::NaiveDateTime;
 use std::{fs::File, path::Path};
 use tracing::metadata::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     fmt, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
 };
-
-/// Convert the value of timestamp nanosecond(i64) to zeek's timestamp format.
-#[must_use]
-pub fn convert_time_format(timestamp: i64) -> String {
-    const A_BILLION: i64 = 1_000_000_000;
-    let nsecs = u32::try_from(timestamp % A_BILLION).unwrap_or_default();
-    NaiveDateTime::from_timestamp_opt(timestamp / A_BILLION, nsecs)
-        .map_or("-".to_string(), |s| s.format("%s%.9f").to_string())
-}
 
 /// Init operation log with tracing
 ///


### PR DESCRIPTION
`convert_time_format` function is no longer available as a public function in the API. It has been made private to avoid exposing the internal protocol format used for network transmission.