### PR TITLE
Update quinn to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated quinn from 0.9 to 0.10, and rustls from 0.20 to 0.21. As
+  giganto-client exposes quinn's structs in its public API, it is important to
+  make sure you update your direct dependencies on both quinn and rustls to the
+  same versions as required by giganto-client.
+
 ### Removed
 
 - Moved `send_crusher_stream_start_message` and `send_crusher_data` to Giganto.
@@ -74,6 +81,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[Unreleased]: https://github.com/aicers/giganto-client/compare/0.6.0...main
 [0.6.0]: https://github.com/aicers/giganto-client/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/aicers/giganto-client/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/aicers/giganto-client/compare/0.3.1...0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 bincode = "1"
 chrono = { version = "0.4", features = ["serde"] }
 num_enum = "0.6"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.6.0" }
-quinn = "0.9"
+oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.7.0" }
+quinn = "0.10"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
@@ -28,5 +28,5 @@ tracing-subscriber = { version = "0.3", features = [
 futures = "0.3"
 lazy_static = "1"
 rcgen = "0.10"
-rustls = "0.20"
+rustls = "0.21"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }


### PR DESCRIPTION
Updated quinn from 0.9 to 0.10, and rustls from 0.20 to 0.21. As giganto-client exposes quinn's structs in its public API, it is important to make sure users of giganto-client update their direct dependencies on both quinn and rustls to the same versions as required by giganto-client.