### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2023-06-12
 
 ### Added
 
@@ -100,7 +100,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
-[Unreleased]: https://github.com/aicers/giganto-client/compare/0.7.0...main
+[0.8.0]: https://github.com/aicers/giganto-client/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/aicers/giganto-client/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/aicers/giganto-client/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/aicers/giganto-client/compare/0.4.0...0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,7 +10,6 @@ anyhow = "1.0"
 bincode = "1"
 chrono = { version = "0.4", features = ["serde"] }
 num_enum = "0.6"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.7.0" }
 quinn = "0.10"
 semver = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
- Remove `oinq` from the dependency as it was not being used.