### PR TITLE
Modify the structure and functionality of Reconverge's data requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Change `Log`, `PeriodicTimeSeries` to `ReqRange` in enum `MessageCode`.
+  So when requesting data for analysis, `REconverge` use `MessageCode::ReqRange`.
+- Change the data types that `send_raw_events` and `receive_raw_events` send and
+  receive to `Vec<(i64, String, Vec<u8>)>`.
+
+### Removed
+
+- remove `RequestTimeSeriesRange` structure. So when requesting data for analysis,
+  `REconverge` use `RequestRange` structure.
+
 ## [0.8.0] - 2023-06-12
 
 ### Added
@@ -23,6 +37,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 - Moved `send_ack_timestamp` to Giganto.
+- remove `RequestTimeSeriesRange` structure. So when requesting data for analysis,
+  `REconverge` use `RequestRange` structure.
 
 ## [0.7.0] - 2023-05-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.8.0"
+version = "0.9.0-alpha.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/publish/range.rs
+++ b/src/publish/range.rs
@@ -21,8 +21,7 @@ pub trait ResponseRangeData {
 )]
 #[repr(u32)]
 pub enum MessageCode {
-    Log = 0,
-    PeriodicTimeSeries = 1,
+    ReqRange = 1,
     Pcap = 2,
     RawData = 3,
 }
@@ -42,6 +41,7 @@ pub enum REconvergeKindType {
     Ftp,
     Mqtt,
     Ldap,
+    Timeseries,
 }
 
 impl REconvergeKindType {
@@ -60,6 +60,7 @@ impl REconvergeKindType {
             "ftp" => REconvergeKindType::Ftp,
             "mqtt" => REconvergeKindType::Mqtt,
             "ldap" => REconvergeKindType::Ldap,
+            "timeseries" => REconvergeKindType::Timeseries,
             _ => REconvergeKindType::Log,
         }
     }
@@ -68,7 +69,7 @@ impl REconvergeKindType {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RequestRange {
-    pub source: String, //certification name
+    pub source: String, //network event: certification name, time_series: sampling policy id
     pub kind: String,
     pub start: i64,
     pub end: i64,
@@ -79,13 +80,4 @@ pub struct RequestRange {
 pub struct RequestRawData {
     pub kind: String,
     pub input: Vec<(String, Vec<i64>)>,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[allow(clippy::module_name_repetitions)]
-pub struct RequestTimeSeriesRange {
-    pub source: String, //sampling policy id
-    pub start: i64,
-    pub end: i64,
-    pub count: usize,
 }


### PR DESCRIPTION
- Change `Log`, `PeriodicTimeSeries` to `ReqRange` in enum `MessageCode`. So when requesting data for analysis, `REconverge` use `MessageCode::ReqRange`.
- remove `RequestTimeSeriesRange` structure. So when requesting data for analysis, `REconverge` use `RequestRange` structure.
- Change the data types that `send_raw_events` and `receive_raw_events` send and receive to `Vec<(i64, String, Vec<u8>)>`.

related : #32 