### PR TITLE
Rename ingest::log::Oplog|Seculog -> ingest::log::OpLog|SecuLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2023-11-07
+
+### Changed
+
+- Renamed ingest::log::Oplog|Seculog -> ingest::log::OpLog|SecuLog
+
 ## [0.14.0] - 2023-11-07
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ingest/log.rs
+++ b/src/ingest/log.rs
@@ -24,8 +24,9 @@ impl ResponseRangeData for Log {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Oplog {
+pub struct OpLog {
     pub agent_name: String,
     pub log_level: OpLogLevel,
     pub contents: String,
@@ -39,7 +40,7 @@ pub enum OpLogLevel {
     Error,
 }
 
-impl Display for Oplog {
+impl Display for OpLog {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -49,8 +50,9 @@ impl Display for Oplog {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Seculog {
+pub struct SecuLog {
     pub kind: String,
     pub log_type: String,
     pub version: String,
@@ -62,7 +64,7 @@ pub struct Seculog {
     pub contents: String,
 }
 
-impl Display for Seculog {
+impl Display for SecuLog {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
# Summary
fixes #78 
Renamed ingest::log::Oplog|Seculog -> ingest::log::OpLog|SecuLog

### Note
Bump version to 0.15.0