### PR TITLE
add MessageCode::StringRawData to send outlier events to REconverge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `MessageCode::StringRawData` to send outlier events to REconverge.
+
 ## [0.15.1] - 2023-11-08
 
 ### Added
@@ -210,6 +216,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[Unreleased]: https://github.com/aicers/giganto-client/compare/0.15.1...main
 [0.15.1]: https://github.com/aicers/giganto-client/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/aicers/giganto-client/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/aicers/giganto-client/compare/0.13.2...0.14.0

--- a/src/publish/range.rs
+++ b/src/publish/range.rs
@@ -24,6 +24,7 @@ pub enum MessageCode {
     ReqRange = 1,
     Pcap = 2,
     RawData = 3,
+    StringRawData = 4,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
### 수정 내용
Add `MessageCode::StringRawData`
* REconverge가 요청한 아웃라이어 이벤트를 REconverge의 입력 이벤트와 같은 CSV 형식으로 전송하기 위한 메시지 코드

### 이슈
REconverge는 아웃라이어 이벤트를 요청할 때 MessageCode::RawData request message를 사용했지만, 응답으로 전송되는 이벤트가
CSV 형식이 아니라 프로토콜 구조체 인스턴스를 Serialize한 값이어서 에러가 발생했습니다.
`MessageCode::RawData` 자체는 UI에서도 사용하는 코드이기때문에 수정할 수 없어서 새로운 요청코드를 생성합니다.
