### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] - 2024-02-16
 
 ### Changed
 
@@ -225,6 +225,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[0.16.0]: https://github.com/aicers/giganto-client/compare/0.15.2...0.16.0
 [0.15.2]: https://github.com/aicers/giganto-client/compare/0.15.1...0.15.2
 [0.15.1]: https://github.com/aicers/giganto-client/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/aicers/giganto-client/compare/0.14.0...0.15.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,8 +13,8 @@ num_enum = "0.7"
 quinn = "0.10"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
-strum = "0.25"
-strum_macros = "0.25"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1"
 tokio = "1"
 tracing = "0.1"

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -111,7 +111,7 @@ fn as_str_or_default(s: &str) -> &str {
     }
 }
 
-fn vec_to_string_or_default<T>(vec: &Vec<T>) -> String
+fn vec_to_string_or_default<T>(vec: &[T]) -> String
 where
     T: Display,
 {


### PR DESCRIPTION
close #104 

신규 추가된 SSH 프로토콜, HTTP/SMTP의 필드 추가 등을 사용하기 위해 릴리즈가 필요합니다.

Giganto에 지금 당장 반영할 필요는 없습니다.