### PR TITLE
Bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.0] - 2024-05-16
 
 ### Added
 
@@ -241,7 +241,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
-[Unreleased]: https://github.com/aicers/giganto-client/compare/0.16.0...main
+[0.17.0]: https://github.com/aicers/giganto-client/compare/0.16.0...0.17.0
 [0.16.0]: https://github.com/aicers/giganto-client/compare/0.15.2...0.16.0
 [0.15.2]: https://github.com/aicers/giganto-client/compare/0.15.1...0.15.2
 [0.15.1]: https://github.com/aicers/giganto-client/compare/0.15.0...0.15.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giganto-client"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
다음 사항이 변경되었습니다.
- TLS 이벤트 구조에 필드 추가
- quinn, rustls, rcgen crate 버전 패치

Close #113 