### PR TITLE
Remove unused `source` field & Rename `source` to `sensor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added `sensor` field to `OpLog`.
 
+### Changed
+
+- Changed `source` to `sensor`, which is a more appropriate term for the name of
+  the device that sensed/captured the raw event.
+
+### Removed
+
+- Removed the unused `source` within the `Netflow5`, `Netflow9`, `SecuLog`.
+
 ## [0.20.0] - 2024-09-10
 
 ### Changed
@@ -57,7 +66,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Modified tls event structure to store: `client_cipher_suites`, `client_extensions`,
-`extensions`
+  `extensions`
 - Bump dependencies.
   - Update quinn to version 0.11.
   - Update rustls to version 0.23.

--- a/src/ingest/log.rs
+++ b/src/ingest/log.rs
@@ -21,8 +21,8 @@ impl Display for Log {
 }
 
 impl ResponseRangeData for Log {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        bincode::serialize(&Some((timestamp, source, &self.log)))
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        bincode::serialize(&Some((timestamp, sensor, &self.log)))
     }
 }
 
@@ -56,7 +56,6 @@ impl Display for OpLog {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SecuLog {
-    pub source: String,
     pub kind: String,
     pub log_type: String,
     pub version: String,
@@ -72,8 +71,7 @@ impl Display for SecuLog {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            self.source,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             self.kind,
             self.log_type,
             self.version,

--- a/src/ingest/netflow.rs
+++ b/src/ingest/netflow.rs
@@ -10,7 +10,6 @@ use crate::{ingest::convert_time_format, publish::range::ResponseRangeData};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct Netflow5 {
-    pub source: String,
     pub src_addr: IpAddr,
     pub dst_addr: IpAddr,
     pub next_hop: IpAddr,
@@ -40,8 +39,7 @@ impl Display for Netflow5 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:x}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:x}\t{}",
-            self.source,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:x}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:x}\t{}",
             self.src_addr,
             self.dst_addr,
             self.next_hop,
@@ -70,16 +68,15 @@ impl Display for Netflow5 {
 }
 
 impl ResponseRangeData for Netflow5 {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let csv = format!("{}\t{self}", convert_time_format(timestamp));
-        bincode::serialize(&Some((timestamp, source, &csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &csv.as_bytes())))
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct Netflow9 {
-    pub source: String,
     pub sequence: u32,
     pub source_id: u32,
     pub template_id: u16,
@@ -95,8 +92,7 @@ impl Display for Netflow9 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            self.source,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             self.sequence,
             self.source_id,
             self.template_id,
@@ -111,9 +107,9 @@ impl Display for Netflow9 {
 }
 
 impl ResponseRangeData for Netflow9 {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let csv = format!("{}\t{self}", convert_time_format(timestamp));
-        bincode::serialize(&Some((timestamp, source, &csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &csv.as_bytes())))
     }
 }
 

--- a/src/ingest/network.rs
+++ b/src/ingest/network.rs
@@ -54,10 +54,10 @@ impl Display for Conn {
 }
 
 impl ResponseRangeData for Conn {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let conn_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let conn_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &conn_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &conn_csv.as_bytes())))
     }
 }
 
@@ -211,10 +211,10 @@ impl Display for Dns {
 }
 
 impl ResponseRangeData for Dns {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let dns_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let dns_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &dns_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &dns_csv.as_bytes())))
     }
 }
 
@@ -292,10 +292,10 @@ impl Display for Http {
 }
 
 impl ResponseRangeData for Http {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let http_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let http_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &http_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &http_csv.as_bytes())))
     }
 }
 
@@ -327,10 +327,10 @@ impl Display for Rdp {
 }
 
 impl ResponseRangeData for Rdp {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let rdp_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let rdp_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &rdp_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &rdp_csv.as_bytes())))
     }
 }
 
@@ -374,10 +374,10 @@ impl Display for Smtp {
 }
 
 impl ResponseRangeData for Smtp {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let smtp_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let smtp_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &smtp_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &smtp_csv.as_bytes())))
     }
 }
 
@@ -417,10 +417,10 @@ impl Display for Ntlm {
 }
 
 impl ResponseRangeData for Ntlm {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let ntlm_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let ntlm_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &ntlm_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &ntlm_csv.as_bytes())))
     }
 }
 
@@ -468,10 +468,10 @@ impl Display for Kerberos {
 }
 
 impl ResponseRangeData for Kerberos {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let kerberos_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let kerberos_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &kerberos_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &kerberos_csv.as_bytes())))
     }
 }
 
@@ -527,10 +527,10 @@ impl Display for Ssh {
 }
 
 impl ResponseRangeData for Ssh {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let ssh_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let ssh_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &ssh_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &ssh_csv.as_bytes())))
     }
 }
 
@@ -568,10 +568,10 @@ impl Display for DceRpc {
 }
 
 impl ResponseRangeData for DceRpc {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let dce_rpc_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let dce_rpc_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &dce_rpc_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &dce_rpc_csv.as_bytes())))
     }
 }
 
@@ -625,10 +625,10 @@ impl Display for Ftp {
 }
 
 impl ResponseRangeData for Ftp {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let ftp_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let ftp_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &ftp_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &ftp_csv.as_bytes())))
     }
 }
 
@@ -670,10 +670,10 @@ impl Display for Mqtt {
 }
 
 impl ResponseRangeData for Mqtt {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let mqtt_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let mqtt_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &mqtt_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &mqtt_csv.as_bytes())))
     }
 }
 
@@ -717,10 +717,10 @@ impl Display for Ldap {
 }
 
 impl ResponseRangeData for Ldap {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let ldap_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let ldap_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &ldap_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &ldap_csv.as_bytes())))
     }
 }
 
@@ -792,10 +792,10 @@ impl Display for Tls {
 }
 
 impl ResponseRangeData for Tls {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let tls_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let tls_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &tls_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &tls_csv.as_bytes())))
     }
 }
 
@@ -848,10 +848,10 @@ impl Display for Smb {
 }
 
 impl ResponseRangeData for Smb {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let smb_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let smb_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &smb_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &smb_csv.as_bytes())))
     }
 }
 
@@ -885,10 +885,10 @@ impl Display for Nfs {
 }
 
 impl ResponseRangeData for Nfs {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let nfs_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let nfs_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &nfs_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &nfs_csv.as_bytes())))
     }
 }
 
@@ -940,10 +940,10 @@ impl Display for Bootp {
 }
 
 impl ResponseRangeData for Bootp {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let bootp_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let bootp_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &bootp_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &bootp_csv.as_bytes())))
     }
 }
 
@@ -1009,9 +1009,9 @@ impl Display for Dhcp {
 }
 
 impl ResponseRangeData for Dhcp {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let dhcp_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let dhcp_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &dhcp_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &dhcp_csv.as_bytes())))
     }
 }

--- a/src/ingest/sysmon.rs
+++ b/src/ingest/sysmon.rs
@@ -70,10 +70,10 @@ impl Display for ProcessCreate {
 }
 
 impl ResponseRangeData for ProcessCreate {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let process_create_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let process_create_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &process_create_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &process_create_csv.as_bytes())))
     }
 }
 
@@ -109,10 +109,10 @@ impl Display for FileCreationTimeChanged {
 }
 
 impl ResponseRangeData for FileCreationTimeChanged {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let file_create_time_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let file_create_time_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &file_create_time_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &file_create_time_csv.as_bytes())))
     }
 }
 
@@ -166,10 +166,10 @@ impl Display for NetworkConnection {
 }
 
 impl ResponseRangeData for NetworkConnection {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let network_connect_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let network_connect_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &network_connect_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &network_connect_csv.as_bytes())))
     }
 }
 
@@ -199,12 +199,12 @@ impl Display for ProcessTerminated {
 }
 
 impl ResponseRangeData for ProcessTerminated {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let process_terminate_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let process_terminate_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
         bincode::serialize(&Some((
             timestamp,
-            source,
+            sensor,
             &process_terminate_csv.as_bytes(),
         )))
     }
@@ -255,10 +255,10 @@ impl Display for ImageLoaded {
 }
 
 impl ResponseRangeData for ImageLoaded {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let image_load_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let image_load_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &image_load_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &image_load_csv.as_bytes())))
     }
 }
 
@@ -292,10 +292,10 @@ impl Display for FileCreate {
 }
 
 impl ResponseRangeData for FileCreate {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let file_create_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let file_create_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &file_create_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &file_create_csv.as_bytes())))
     }
 }
 
@@ -331,13 +331,13 @@ impl Display for RegistryValueSet {
 }
 
 impl ResponseRangeData for RegistryValueSet {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let registry_value_set_csv =
-            format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+            format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
         bincode::serialize(&Some((
             timestamp,
-            source,
+            sensor,
             &registry_value_set_csv.as_bytes(),
         )))
     }
@@ -375,13 +375,13 @@ impl Display for RegistryKeyValueRename {
 }
 
 impl ResponseRangeData for RegistryKeyValueRename {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let registry_key_rename_csv =
-            format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+            format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
         bincode::serialize(&Some((
             timestamp,
-            source,
+            sensor,
             &registry_key_rename_csv.as_bytes(),
         )))
     }
@@ -421,13 +421,13 @@ impl Display for FileCreateStreamHash {
 }
 
 impl ResponseRangeData for FileCreateStreamHash {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let file_create_stream_hash_csv =
-            format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+            format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
         bincode::serialize(&Some((
             timestamp,
-            source,
+            sensor,
             &file_create_stream_hash_csv.as_bytes(),
         )))
     }
@@ -463,10 +463,10 @@ impl Display for PipeEvent {
 }
 
 impl ResponseRangeData for PipeEvent {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let pipe_event_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let pipe_event_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &pipe_event_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &pipe_event_csv.as_bytes())))
     }
 }
 
@@ -502,10 +502,10 @@ impl Display for DnsEvent {
 }
 
 impl ResponseRangeData for DnsEvent {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let dns_event_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let dns_event_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &dns_event_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &dns_event_csv.as_bytes())))
     }
 }
 
@@ -543,10 +543,10 @@ impl Display for FileDelete {
 }
 
 impl ResponseRangeData for FileDelete {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let file_delete_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let file_delete_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &file_delete_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &file_delete_csv.as_bytes())))
     }
 }
 
@@ -578,10 +578,10 @@ impl Display for ProcessTampering {
 }
 
 impl ResponseRangeData for ProcessTampering {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        let process_tamper_csv = format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        let process_tamper_csv = format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
-        bincode::serialize(&Some((timestamp, source, &process_tamper_csv.as_bytes())))
+        bincode::serialize(&Some((timestamp, sensor, &process_tamper_csv.as_bytes())))
     }
 }
 
@@ -617,13 +617,13 @@ impl Display for FileDeleteDetected {
 }
 
 impl ResponseRangeData for FileDeleteDetected {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
         let file_delete_detected_csv =
-            format!("{}\t{source}\t{self}", convert_time_format(timestamp));
+            format!("{}\t{sensor}\t{self}", convert_time_format(timestamp));
 
         bincode::serialize(&Some((
             timestamp,
-            source,
+            sensor,
             &file_delete_detected_csv.as_bytes(),
         )))
     }

--- a/src/ingest/timeseries.rs
+++ b/src/ingest/timeseries.rs
@@ -18,8 +18,8 @@ impl Display for PeriodicTimeSeries {
 }
 
 impl ResponseRangeData for PeriodicTimeSeries {
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error> {
-        bincode::serialize(&Some((timestamp, source, &self.data)))
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error> {
+        bincode::serialize(&Some((timestamp, sensor, &self.data)))
     }
     fn response_done() -> Result<Vec<u8>, bincode::Error> {
         bincode::serialize::<Option<(i64, String, Vec<f64>)>>(&None)

--- a/src/publish/range.rs
+++ b/src/publish/range.rs
@@ -6,7 +6,7 @@ pub trait ResponseRangeData {
     /// # Errors
     ///
     /// Will return `Err` if response data's serialize faild.
-    fn response_data(&self, timestamp: i64, source: &str) -> Result<Vec<u8>, bincode::Error>;
+    fn response_data(&self, timestamp: i64, sensor: &str) -> Result<Vec<u8>, bincode::Error>;
 
     /// # Errors
     ///
@@ -29,7 +29,7 @@ pub enum MessageCode {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RequestRange {
-    pub source: String, //network event: certification name, time_series: sampling policy id
+    pub sensor: String, //network event: certification name, time_series: sampling policy id
     pub kind: String,
     pub start: i64,
     pub end: i64,

--- a/src/publish/stream.rs
+++ b/src/publish/stream.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-pub const STREAM_REQUEST_ALL_SOURCE: &str = "all";
+pub const STREAM_REQUEST_ALL_SENSOR: &str = "all";
 
 #[derive(
     Clone,
@@ -81,7 +81,7 @@ impl RequestStreamRecord {
 #[allow(clippy::module_name_repetitions)]
 pub struct RequestHogStream {
     pub start: i64,
-    pub source: Option<Vec<String>>,
+    pub sensor: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -91,7 +91,7 @@ pub struct RequestCrusherStream {
     pub id: String,
     pub src_ip: Option<IpAddr>,
     pub dst_ip: Option<IpAddr>,
-    pub source: Option<String>,
+    pub sensor: Option<String>,
 }
 
 #[test]


### PR DESCRIPTION
- Remove unused `source` within the `Netflow5`, `Netflow9`, `SecuLog`.
- Change `source` to `sensor`, which is a more appropriate term for the name of the device that sensed/captured the raw event.

Close: #138
Close: #139