### PR TITLE
Rename private module names to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Renamed identifiers referencing the semi-supervised engine. Updated identifers
+  include:
+  - `NodeType::SemiSupervised`
+  - `RequestSemiSupervisedStream`
+  - `send_semi_supervised_stream_start_message`
+  - `receive_semi_supervised_stream_start_message`
+  - `receive_semi_supervised_data`
+- Renamed `Crusher` to `TimeSeriesGenerator` for consistency with the
+  review-database. Updated identifers include:
+  - `NodeType::TimeSeriesGenerator`
+  - `RequestTimeSeriesGeneratorStream`
+  - `receive_time_series_generator_stream_start_message`
+  - `receive_time_series_generator_data`
+
 ## [0.21.0] - 2024-11-21
 
 ### Added
@@ -292,6 +310,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[Unreleased]: https://github.com/aicers/giganto-client/compare/0.21.0...main
 [0.21.0]: https://github.com/aicers/giganto-client/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/aicers/giganto-client/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/aicers/giganto-client/compare/0.18.0...0.19.0

--- a/src/publish/stream.rs
+++ b/src/publish/stream.rs
@@ -23,8 +23,8 @@ pub const STREAM_REQUEST_ALL_SENSOR: &str = "all";
 #[repr(u8)]
 #[strum(serialize_all = "snake_case")]
 pub enum NodeType {
-    Hog = 0,
-    Crusher = 1,
+    SemiSupervised = 0,
+    TimeSeriesGenerator = 1,
 }
 
 #[derive(
@@ -79,14 +79,14 @@ impl RequestStreamRecord {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
-pub struct RequestHogStream {
+pub struct RequestSemiSupervisedStream {
     pub start: i64,
     pub sensor: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::module_name_repetitions)]
-pub struct RequestCrusherStream {
+pub struct RequestTimeSeriesGeneratorStream {
     pub start: i64,
     pub id: String,
     pub src_ip: Option<IpAddr>,
@@ -100,11 +100,20 @@ fn test_node_stream_record_type() {
     use std::str::FromStr;
 
     // test NodeType
-    assert_eq!(NodeType::Hog, NodeType::from_str("hog").unwrap());
-    assert_eq!(NodeType::Hog.to_string(), "hog");
+    assert_eq!(
+        NodeType::SemiSupervised,
+        NodeType::from_str("semi_supervised").unwrap()
+    );
+    assert_eq!(NodeType::SemiSupervised.to_string(), "semi_supervised");
 
-    assert_eq!(NodeType::Crusher, NodeType::from_str("crusher").unwrap());
-    assert_eq!(NodeType::Crusher.to_string(), "crusher");
+    assert_eq!(
+        NodeType::TimeSeriesGenerator,
+        NodeType::from_str("time_series_generator").unwrap()
+    );
+    assert_eq!(
+        NodeType::TimeSeriesGenerator.to_string(),
+        "time_series_generator"
+    );
 
     // test RequestStreamRecord
     assert_eq!(


### PR DESCRIPTION
Although `Crusher` is already public, it's been renamed to `TimeSeriesGenerator` for consistency with the review-database.

Didn't update `CHANGELOG.MD`, considering its purpose as a log.

Close: #146