### PR TITLE
Removed the `init_tracing` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- Removed `init_tracing` function to align giganto-client's responsibilities as
+  a communication library.
+
 ## [0.22.0] - 2025-01-24
 
 ### Changed
@@ -311,6 +318,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move from giganto
 
+[Unreleased]: https://github.com/aicers/giganto-client/compare/0.22.0...main
 [0.22.0]: https://github.com/aicers/giganto-client/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/aicers/giganto-client/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/aicers/giganto-client/compare/0.19.0...0.20.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,6 @@ strum = "0.26"
 strum_macros = "0.26"
 thiserror = "2"
 tokio = "1"
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = [
-  "env-filter",
-  "fmt",
-  "std",
-] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,10 @@ pub mod publish;
 mod test;
 
 use std::default::Default;
-use std::{fs::File, path::Path};
 
-use anyhow::{bail, Result};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumString;
-use tracing::metadata::LevelFilter;
-use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{
-    fmt, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
-};
 
 /// A raw data type for sending/receiving raw events with Giganto server.
 /// `RawEventKind` can be used in any communication modes (i.e. ingest, publish)
@@ -84,42 +77,6 @@ pub enum RawEventKind {
 
     Netflow5 = 60,
     Netflow9 = 61,
-}
-
-/// Init operation log with tracing
-///
-/// This function has parameter `pkg_name` with `env!("CARGO_PKG_NAME")`
-///
-/// # Errors
-///
-/// * Path not exist
-/// * Invalid path
-///
-pub fn init_tracing(path: &Path, pkg_name: &str) -> Result<WorkerGuard> {
-    if !path.exists() {
-        tracing_subscriber::fmt::init();
-        bail!("Path not found {path:?}");
-    }
-    let file_name = format!("{pkg_name}.log");
-    if File::create(path.join(file_name.clone())).is_err() {
-        tracing_subscriber::fmt::init();
-        bail!("Cannot create file. {}/{file_name}", path.display());
-    }
-    let file_appender = tracing_appender::rolling::never(path, file_name);
-    let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
-    let layer_file = fmt::Layer::default()
-        .with_ansi(false)
-        .with_target(false)
-        .with_writer(file_writer)
-        .with_filter(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()));
-    let layer_stdout = fmt::Layer::default()
-        .with_ansi(true)
-        .with_filter(EnvFilter::from_default_env());
-    tracing_subscriber::registry()
-        .with(layer_file)
-        .with(layer_stdout)
-        .init();
-    Ok(guard)
 }
 
 #[test]


### PR DESCRIPTION
## Related Issue
- Close #158

## PR Description
- Removed the `init_tracing` function and all associated dependencies:
  - `tracing`
  - `tracing-subscriber`
  - `tracing-appender`
- Updated `Changelog.md` to reflect the removal of tracing-related components.