### PR TITLE
Add runtime buffer sizing to prevent OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Added runtime buffer sizing logic `prepare_buf` to prevent OOM during receive
+  and safely handle variable frame sizes.
+
 ### Fixed
 
 - Fixed inconsistent formatting of negative timestamps in `convert_time_format`.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -67,7 +67,7 @@ pub async fn client_handshake(
                 return Err(HandshakeError::ReadError(e));
             }
         },
-        Err(RecvError::MessageTooLarge(_)) => {
+        Err(RecvError::MessageTooLarge) => {
             return Err(HandshakeError::MessageTooLarge);
         }
         Ok(()) | Err(_) => {}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 pub enum RecvError {
     #[error("Failed deserializing message")]
     DeserializationFailure(#[from] bincode::Error),
-    #[error("Receive message is too large, so type casting failed")]
-    MessageTooLarge(#[from] TryFromIntError),
+    #[error("Receive message is too large")]
+    MessageTooLarge,
     #[error("Failed to read from a stream")]
     ReadError(#[from] quinn::ReadExactError),
 }
@@ -35,6 +35,7 @@ pub enum SendError {
 /// * `RecvError::DeserializationFailure`: if the message could not be
 ///   deserialized
 /// * `RecvError::ReadError`: if the message could not be read
+/// * `RecvError::MessageTooLarge`: if the message exceeds the maximum size
 pub async fn recv<'b, T>(recv: &mut RecvStream, buf: &'b mut Vec<u8>) -> Result<T, RecvError>
 where
     T: Deserialize<'b>,
@@ -51,11 +52,11 @@ where
 /// # Errors
 ///
 /// * `RecvError::ReadError`: if the message could not be read
+/// * `RecvError::MessageTooLarge`: if the message exceeds the maximum size
 pub async fn recv_raw(recv: &mut RecvStream, buf: &mut Vec<u8>) -> Result<(), RecvError> {
     let mut len_buf = [0; mem::size_of::<u32>()];
     recv.read_exact(&mut len_buf).await?;
-    let len = u32::from_le_bytes(len_buf) as usize;
-    buf.resize(len, 0);
+    prepare_buf(buf, u32::from_le_bytes(len_buf).into())?;
     recv.read_exact(buf.as_mut_slice()).await?;
     Ok(())
 }
@@ -72,8 +73,7 @@ pub async fn recv_raw(recv: &mut RecvStream, buf: &mut Vec<u8>) -> Result<(), Re
 pub async fn recv_handshake(recv: &mut RecvStream, buf: &mut Vec<u8>) -> Result<(), RecvError> {
     let mut len_buf = [0; mem::size_of::<u64>()];
     recv.read_exact(&mut len_buf).await?;
-    let len: usize = u64::from_le_bytes(len_buf).try_into()?;
-    buf.resize(len, 0);
+    prepare_buf(buf, u64::from_le_bytes(len_buf))?;
     recv.read_exact(buf.as_mut_slice()).await?;
     Ok(())
 }
@@ -146,6 +146,16 @@ pub async fn send_handshake(send: &mut SendStream, buf: &[u8]) -> Result<(), Sen
     Ok(())
 }
 
+fn prepare_buf(buf: &mut Vec<u8>, len: u64) -> Result<(), RecvError> {
+    let len = usize::try_from(len).map_err(|_| RecvError::MessageTooLarge)?;
+    if len > buf.len() {
+        buf.try_reserve(len - buf.len())
+            .map_err(|_| RecvError::MessageTooLarge)?;
+    }
+    buf.resize(len, 0);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #[tokio::test]
@@ -198,5 +208,77 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(received, "hello");
+    }
+
+    #[test]
+    fn prepare_buf_success() {
+        let mut buf = Vec::new();
+        let len = 1024;
+        super::prepare_buf(&mut buf, len).unwrap();
+        assert_eq!(buf.len(), 1024);
+        assert!(buf.capacity() >= 1024);
+    }
+
+    #[test]
+    fn prepare_buf_too_large() {
+        let mut buf = Vec::new();
+        // On 64-bit, this tries to allocate u64::MAX bytes, which fails.
+        // On 32-bit, this fails integer conversion.
+        let len = u64::MAX;
+        let result = super::prepare_buf(&mut buf, len);
+        assert!(matches!(result, Err(super::RecvError::MessageTooLarge)));
+    }
+
+    #[test]
+    fn prepare_buf_allocation_failure() {
+        let mut buf = Vec::new();
+        // This fits in usize, so it passes the integer conversion check.
+        // However, allocating usize::MAX bytes is practically impossible, so try_reserve fails.
+        let len = usize::MAX as u64;
+        let result = super::prepare_buf(&mut buf, len);
+        assert!(matches!(result, Err(super::RecvError::MessageTooLarge)));
+    }
+
+    #[tokio::test]
+    async fn frame_error_cases() {
+        use crate::test::{TOKEN, channel};
+
+        let _lock = TOKEN.lock().await;
+        let mut channel = channel().await;
+
+        // Test RecvError::DeserializationFailure
+        let mut buf = Vec::new();
+        // Send a message that is clearly not a valid bincode for a complex struct.
+        // Let's try to deserialize into a Vec<u32> from a single byte.
+        super::send_raw(&mut channel.server.send, b"1")
+            .await
+            .unwrap();
+        let result = super::recv::<Vec<u32>>(&mut channel.client.recv, &mut buf).await;
+        assert!(matches!(
+            result,
+            Err(super::RecvError::DeserializationFailure(_))
+        ));
+
+        // Test MessageTooLarge during recv
+        // Let's try a reliable way to trigger MessageTooLarge:
+        // 8-byte length in recv_handshake with u64::MAX.
+        let huge_len_buf_64 = [255u8; 8];
+        channel
+            .server
+            .send
+            .write_all(&huge_len_buf_64)
+            .await
+            .unwrap();
+        let result = super::recv_handshake(&mut channel.client.recv, &mut buf).await;
+        assert!(matches!(result, Err(super::RecvError::MessageTooLarge)));
+
+        // Test Empty Message
+        super::send_raw(&mut channel.server.send, b"")
+            .await
+            .unwrap();
+        super::recv_raw(&mut channel.client.recv, &mut buf)
+            .await
+            .unwrap();
+        assert!(buf.is_empty());
     }
 }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -50,7 +50,7 @@ impl From<frame::RecvError> for PublishError {
                 quinn::ReadExactError::FinishedEarly(_) => PublishError::ConnectionClosed,
                 quinn::ReadExactError::ReadError(e) => PublishError::ReadError(e),
             },
-            RecvError::MessageTooLarge(_) => PublishError::MessageTooLarge,
+            RecvError::MessageTooLarge => PublishError::MessageTooLarge,
         }
     }
 }


### PR DESCRIPTION
Add `prepare_buf` for runtime buffer sizing during receive to
prevent OOM conditions and properly support variable frame sizes.
This improves safety when handling untrusted or large frame inputs.

Close #252